### PR TITLE
Set GOPATH and edit ENV PATH

### DIFF
--- a/Dockerfile_fed36_arm
+++ b/Dockerfile_fed36_arm
@@ -40,8 +40,10 @@ RUN dnf update -y \
     && make \
     && make install \
 # Install siegfried
+    && export GOPATH=$(go env GOPATH) \
+    && GOPATH=/usr/local/go \
     && go install github.com/richardlehane/siegfried/cmd/sf@latest \
-    && /root/go/bin/sf -update \
+    && /usr/local/go/bin/sf -update \
 # Install hfsexplorer
     && mkdir /usr/share/hfsexplorer \
     && cd /usr/share/hfsexplorer \
@@ -64,7 +66,7 @@ RUN dnf update -y \
     && rm -r /home/repos/dfxml_python \
     && rm -r /home/repos/bulk_extractor
 
-ENV PATH="$HOME/go/bin:$PATH"
+ENV PATH="$PATH:/usr/local/go/bin"
 
 # CMD sf -update; freshclam
 


### PR DESCRIPTION
I set the GOPATH so that go install doesn't put things in /root/go/bin anymore. Instead it uses /usr/local/go/bin. Thus, non-root users can access siegfried. I also updated ENV. I can talk more about this tomorrow.